### PR TITLE
Make a copy of the dependencies list

### DIFF
--- a/geo/management/commands/dumpdata.py
+++ b/geo/management/commands/dumpdata.py
@@ -124,7 +124,7 @@ def sort_dependencies(app_list):
             models.add(model)
             # Add any explicitly defined dependencies
             if hasattr(model, 'natural_key'):
-                deps = getattr(model.natural_key, 'dependencies', [])
+                deps = list(getattr(model.natural_key, 'dependencies', []))
                 if deps:
                     deps = [get_model(*d.split('.')) for d in deps]
             else:


### PR DESCRIPTION
Make a copy of the dependencies list so that, if the natural_key method is defined on a super class, we don't end up modifying the dependencies for all classes that inherit it.
